### PR TITLE
updated to work with the latest QB

### DIFF
--- a/hh_aidoc[QB]/client.lua
+++ b/hh_aidoc[QB]/client.lua
@@ -2,6 +2,7 @@ local Active = false
 local test = nil
 local test1 = nil
 local spam = true
+local QBCore = exports['qb-core']:GetCoreObject()
 
  
 

--- a/hh_aidoc[QB]/fxmanifest.lua
+++ b/hh_aidoc[QB]/fxmanifest.lua
@@ -16,6 +16,5 @@ server_scripts {
 }
 
 shared_scripts {
-    '@qb-core/import.lua',
     'config.lua'
 } 


### PR DESCRIPTION
removed the import.lua from fxmanifest and added a line of code to the client so it can find the global QBCore which is what the import.lua used to do in previous versions